### PR TITLE
enhancement/errorEventOnBotLoadFailed

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,7 +33,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git" branch="master"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="YMChat" spec="~> 1.23.0" swift-version="5.0"/>
+                <pod name="YMChat" spec="~> 1.24.0" swift-version="5.0"/>
             </pods>
         </podspec>
         <config-file parent="/*" target="config.xml">

--- a/src/android/com/yellow/ai/ymchat/YmChatCordova.java
+++ b/src/android/com/yellow/ai/ymchat/YmChatCordova.java
@@ -47,6 +47,9 @@ public class YmChatCordova extends CordovaPlugin {
       case "onBotClose":
         onBotClose(callbackContext);
         return true;
+      case "onBotLoadFailed":
+        onBotLoadFailed(callbackContext);
+        return true;
       case "startChatbot":
         startChatbot(callbackContext);
         return true;
@@ -262,6 +265,10 @@ public class YmChatCordova extends CordovaPlugin {
 
   public void onBotClose(CallbackContext onBotCloseEvent) {
     ymChatService.onBotClose(onBotCloseEvent);
+  }
+
+  public void onBotLoadFailed(CallbackContext onBotLoadFailedEvent) {
+    ymChatService.onBotLoadFailed(onBotLoadFailedEvent);
   }
 
   private void unlinkDeviceToken(JSONArray args, CallbackContext callbackContext) {

--- a/src/android/com/yellow/ai/ymchat/YmChatService.java
+++ b/src/android/com/yellow/ai/ymchat/YmChatService.java
@@ -120,6 +120,19 @@ public class YmChatService {
     });
   }
 
+  public void onBotLoadFailed(CallbackContext callback) {
+    ymChat.onBotLoadFailed(() ->
+    {
+      try {
+        PluginResult result = new PluginResult(PluginResult.Status.OK);
+        result.setKeepCallback(true);
+        callback.sendPluginResult(result);
+      } catch (Exception e) {
+        Log.e(Tag, ExceptionString, e);
+      }
+    });
+  }
+
   public void unlinkDeviceToken(String apiKey, CallbackContext callbackContext) {
     try{
       ymChat.unlinkDeviceToken(apiKey, ymChat.config, new YellowCallback() {

--- a/src/ios/ymchat.m
+++ b/src/ios/ymchat.m
@@ -8,6 +8,7 @@
 {
     CDVInvokedUrlCommand* onEvent;
     CDVInvokedUrlCommand* onBotClosed;
+    CDVInvokedUrlCommand* onBotLoadFailed;
 }
 
 @end
@@ -80,6 +81,11 @@
     onBotClosed = command;
 }
 
+- (void)onBotLoadFailed:(CDVInvokedUrlCommand*)command
+{
+    onBotLoadFailed = command;
+}
+
 - (void)startChatbot:(CDVInvokedUrlCommand*)command
 {
     assert(YMChat.shared.config != nil);
@@ -114,6 +120,13 @@
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Hello"];
     [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:onBotClosed.callbackId];
+}
+
+- (void) onBotLoadFailed {
+    CDVPluginResult* pluginResult = nil;
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Bot Load Failed"];
+    [pluginResult setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:onBotLoadFailed.callbackId];
 }
 
 - (void)setVersion:(CDVInvokedUrlCommand*)command

--- a/www/ymchat.js
+++ b/www/ymchat.js
@@ -29,6 +29,9 @@ const YmChatAPI = {
   onBotClose: (onBotCloseEvent) => {
     exec(onBotCloseEvent, null, "ymchat", "onBotClose", []);
   },
+  onBotLoadFailed: (onBotLoadFailedEvent) => {
+    exec(onBotLoadFailedEvent, null, "ymchat", "onBotLoadFailed", []);
+  },
   startChatbot: (success, failure) => {
     exec(success, failure, "ymchat", "startChatbot", []);
   },


### PR DESCRIPTION
Added `onBotLoadFailed` event handler to let user know that bot load failed due to certain outage.

```javascript
cordova.plugins.ymchat.onBotLoadFailed(() => {
   console.log('Bot load failed');
});
```


https://github.com/user-attachments/assets/2705e780-82b6-4266-bd5a-50981912f681



https://github.com/user-attachments/assets/843849e2-3c7c-439f-a9bd-cffc6f034816



